### PR TITLE
test: skip poll test instead of cycling

### DIFF
--- a/test/cli/tarantool-poll.skipcond
+++ b/test/cli/tarantool-poll.skipcond
@@ -1,0 +1,7 @@
+import resource
+
+soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+if soft < 2080 and soft != resource.RLIM_INFINITY:
+    self.skip = True
+
+# vim: set ft=python:


### PR DESCRIPTION
This test opens 2048 sockets and so needs rlimit about number of open
files to be at least 2053 (when it is run under test-run).

This patch mark the test as skipped when the rlimit is less then needed
value (with some gap just in case). Before this patch the test cycles
when there was the limit less then needed, which is not convenient.