### PR TITLE
test: fix tnt_deauth() test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
       - ENCRYPTION_LABEL="27298b445e90"
     matrix:
       - TARGET=documentation
-      - TARGET=test TARANTOOL_REPO=1.7
-      - TARGET=test TARANTOOL_REPO=1.9
       - TARGET=test TARANTOOL_REPO=1.10
       - TARGET=test TARANTOOL_REPO=2x
       - TARGET=test TARANTOOL_REPO=2.2
@@ -83,16 +81,6 @@ before_deploy:
 
 deploy:
   # Deploy packages to PackageCloud
-  - provider: packagecloud
-    username: tarantool
-    repository: "1_9"
-    token: ${PACKAGECLOUD_TOKEN}
-    dist: ${OS}/${DIST}
-    package_glob: build/*.{rpm,deb}
-    skip_cleanup: true
-    on:
-      branch: master
-      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   - provider: packagecloud
     username: tarantool
     repository: "1_10"

--- a/test/unix/tarantool_unix.c
+++ b/test/unix/tarantool_unix.c
@@ -95,7 +95,7 @@ test_auth_call(const char *uri) {
 
 	tnt_reply_init(&reply);
 	isnt(tnt->read_reply(tnt, &reply), -1, "Read reply from server");
-	isnt(reply.error, NULL, "Check error absence");
+	is(reply.error, NULL, "Check error absence");
 	tnt_reply_free(&reply);
 
 	isnt(tnt_call_16(tnt, "test_4", 6, args), -1, "Create call request");


### PR DESCRIPTION
The test case was mistakely changed in [1], because tarantool's
behaviour was incorrect for a while: it does not permit to authenticate
as 'guest' without a password. The tarantool's behaviour was fixed in
[2] and now the incorrect test case fails. The time to fix the test case
back.

Removed tarantool 1.7 and 1.9 from CI, because of two reasons: they are
not more supported, they show previous incorrect behaviour.

[1]: 0882011dac802b892517f6c4e26716c639da0d49 ('Fix a typo "is" ->
     "isnt" since previous connected test expect success')
[2]: https://github.com/tarantool/tarantool/issues/4327