### PR TITLE
travis-ci: update distributives and repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,19 @@ env:
       - TARGET=test TARANTOOL_REPO=1.10
       - TARGET=test TARANTOOL_REPO=2x
       - TARGET=test TARANTOOL_REPO=2.2
+      - TARGET=test TARANTOOL_REPO=2.3
       - OS=el DIST=6
       - OS=el DIST=7
+      - OS=el DIST=8
       - OS=fedora DIST=28
       - OS=fedora DIST=29
+      - OS=fedora DIST=30
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
       - OS=ubuntu DIST=cosmic
       - OS=ubuntu DIST=disco
+      - OS=ubuntu DIST=eoan
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster
@@ -41,9 +45,13 @@ matrix:
         compiler: clang
       - env: OS=el DIST=7
         compiler: clang
+      - env: OS=el DIST=8
+        compiler: clang
       - env: OS=fedora DIST=28
         compiler: clang
       - env: OS=fedora DIST=29
+        compiler: clang
+      - env: OS=fedora DIST=30
         compiler: clang
       - env: OS=ubuntu DIST=trusty
         compiler: clang
@@ -54,6 +62,8 @@ matrix:
       - env: OS=ubuntu DIST=cosmic
         compiler: clang
       - env: OS=ubuntu DIST=disco
+        compiler: clang
+      - env: OS=ubuntu DIST=eoan
         compiler: clang
       - env: OS=debian DIST=jessie
         compiler: clang
@@ -104,6 +114,16 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}


### PR DESCRIPTION
Added builds for CentOS 8, Fedora 30 and Ubuntu Eoan (19.10).

Added a testing job with tarantool-2.3 and enable deployment into 2.3
repository.