### PR TITLE
travis-ci: update distros and repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,16 @@ deploy:
     on:
       branch: master
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=cosmic
-      - OS=ubuntu DIST=disco
       - OS=ubuntu DIST=eoan
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
@@ -58,10 +56,6 @@ matrix:
       - env: OS=ubuntu DIST=xenial
         compiler: clang
       - env: OS=ubuntu DIST=bionic
-        compiler: clang
-      - env: OS=ubuntu DIST=cosmic
-        compiler: clang
-      - env: OS=ubuntu DIST=disco
         compiler: clang
       - env: OS=ubuntu DIST=eoan
         compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
       - OS=ubuntu DIST=eoan
+      - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster
@@ -58,6 +59,8 @@ matrix:
       - env: OS=ubuntu DIST=bionic
         compiler: clang
       - env: OS=ubuntu DIST=eoan
+        compiler: clang
+      - env: OS=ubuntu DIST=focal
         compiler: clang
       - env: OS=debian DIST=jessie
         compiler: clang


### PR DESCRIPTION
Removed Ubuntu Cosmic and Disco.
Added Ubuntu Focal (20.04).
Added 2.4 RPM / Deb repository.

Requested in https://github.com/tarantool/tarantool/issues/4863