### PR TITLE
Fix packing of unsigned numbers in tnt_object_vformat

### DIFF
--- a/test/common/box.lua
+++ b/test/common/box.lua
@@ -41,8 +41,11 @@ box.once('init', function()
     msgpack:insert{3, 'array with float key as key', {[{[2.7] = 3, [7] = 7}] = {1, 2, 3}}}
     msgpack:insert{6, 'array with string key as key', {['megusta'] = {1, 2, 3}}}
 
-    box.schema.func.create('test_4')
-    box.schema.user.grant('guest', 'execute', 'function', 'test_4');
+    -- Grant the following functions to 'guest' user.
+    for _, func in ipairs({'test_4', 'is_positive'}) do
+        box.schema.func.create(func)
+        box.schema.user.grant('guest', 'execute', 'function', func);
+    end
 end)
 
 function test_1()
@@ -82,4 +85,8 @@ function test_5()
         box.session.push({ position = i, value = 'i love maccartney' })
     end
     return true
+end
+
+function is_positive(x)
+    return x > 0
 end

--- a/tnt/tnt_object.c
+++ b/tnt/tnt_object.c
@@ -418,8 +418,14 @@ ssize_t tnt_object_vformat(struct tnt_stream *s, const char *fmt, va_list vl)
 				assert(false);
 			}
 
-			if (int_status) {
-				if ((rv = tnt_object_add_int(s, int_value)) == -1)
+			if (int_status == 1) {
+				rv = tnt_object_add_int(s, int_value);
+				if (rv == -1)
+					return -1;
+				result += rv;
+			} else if (int_status == 2) {
+				rv = tnt_object_add_uint(s, int_value);
+				if (rv == -1)
 					return -1;
 				result += rv;
 			}


### PR DESCRIPTION
Before this change, a number within the [2^63..2^64-1] range was stored within an `int64_t` variable and encoded as a negative number so. Now `%hhu`, `%hu`, `%u`, `%lu` and `%llu` placeholders are processed correctly.