### PR TITLE
Fix memory leak in `tnt_sbuf_object_grow_stack`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ tarantool-poll
 tarantool-cli
 tarantool-call
 tarantool-unix
+tarantool-leak
 test/var/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,11 @@ add_executable(tarantool-test-disconnect tarantool_disconnect.c)
 set_target_properties(tarantool-test-disconnect PROPERTIES OUTPUT_NAME "tarantool-disconnect")
 target_link_libraries(tarantool-test-disconnect tnt test_common)
 
+project(tarantool-test-leak)
+add_executable(tarantool-test-leak cli/tarantool_leak.c)
+set_target_properties(tarantool-test-leak PROPERTIES OUTPUT_NAME "cli/tarantool-leak")
+target_link_libraries(tarantool-test-leak tnt test_common)
+
 add_custom_target(test
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-run.py -j -1
         --builddir=${CMAKE_BINARY_DIR}

--- a/test/cli/tarantool-leak.test.py
+++ b/test/cli/tarantool-leak.test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -8,7 +8,7 @@ suite_name = 'cli'
 test_name = 'tarantool-leak'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE)
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/test/cli/tarantool-leak.test.py
+++ b/test/cli/tarantool-leak.test.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python2
+
+import os
+import subprocess
+
+suite_name = 'cli'
+
+test_name = 'tarantool-leak'
+path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
+
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE)
+rv = obj.communicate()
+
+print("TAP version 13")
+print(rv[0])

--- a/test/cli/tarantool-poll.test.py
+++ b/test/cli/tarantool-poll.test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -8,7 +8,7 @@ suite_name = 'cli'
 test_name = 'tarantool-poll'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE)
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/test/cli/tarantool-tcp.test.py
+++ b/test/cli/tarantool-tcp.test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -8,7 +8,7 @@ suite_name = 'cli'
 test_name = 'tarantool-tcp'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE)
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/test/cli/tarantool_leak.c
+++ b/test/cli/tarantool_leak.c
@@ -1,0 +1,82 @@
+#include "test.h"
+
+#include <tarantool/tarantool.h>
+#include <tarantool/tnt_net.h>
+#include <tarantool/tnt_opt.h>
+#include <msgpuck.h>
+
+#include "common.h"
+
+const char template_msgpuck[] = "[{\"m\": {\"m\": [], \"m\": [], \"m\": [], \"m\": [], \"m\": {\"m\": [\"a\", \"a\"]}}}]";
+static size_t alloc_size = 0;
+
+static void *
+custom_realloc(void *ptr, size_t size)
+{
+	void *new_ptr;
+	if (ptr == NULL) {
+		if (size != 0) {
+			new_ptr = calloc(1, size + sizeof(size_t *));
+			if (new_ptr != NULL) {
+				*((size_t *)new_ptr) = size;
+				alloc_size += size;
+				return (size_t *)new_ptr + 1;
+			}
+		}
+		return NULL;
+	}
+	if (size) {
+		new_ptr = (size_t *)ptr - 1;
+		size_t psize = *((size_t *)new_ptr);
+		new_ptr = realloc(new_ptr, size + sizeof(size_t *));
+		if (new_ptr != NULL) {
+			*((size_t *)new_ptr) = size;
+			alloc_size += (size - psize);
+			return (size_t *)new_ptr + 1;
+		}
+		return NULL;
+	}
+	new_ptr = (size_t *)ptr - 1;
+	alloc_size -= *((size_t *)new_ptr);
+	free(new_ptr);
+	return NULL;
+}
+
+static int
+test_leak(void)
+{
+	plan(2);
+	tnt_mem_init(custom_realloc);
+	char data[sizeof(template_msgpuck)] = { 0 };
+	struct tnt_stream * stream = tnt_object(NULL);
+	tnt_object_add_array(stream, 1);
+	tnt_object_add_map(stream, 1);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_map(stream, 5);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_array(stream, 0);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_array(stream, 0);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_array(stream, 0);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_array(stream, 0);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_map(stream, 1);
+	tnt_object_add_str(stream, "m", 1);
+	tnt_object_add_array(stream, 2);
+	tnt_object_add_str(stream, "a", 1);
+	tnt_object_add_str(stream, "a", 1);
+	mp_snprint(data, sizeof(data), TNT_SBUF_DATA(stream));
+	ok(!strcmp(data, template_msgpuck), "Check the created msgpuck");
+	tnt_stream_free(stream);
+	ok(alloc_size == 0, "Check memory leak absence");
+	return check_plan();
+}
+
+int main()
+{
+	plan(1);
+	test_leak();
+	return check_plan();
+}

--- a/test/unix/tarantool-unix.test.py
+++ b/test/unix/tarantool-unix.test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -8,7 +8,7 @@ suite_name = 'unix'
 test_name = 'tarantool-unix'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE)
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/tnt/tnt_object.c
+++ b/tnt/tnt_object.c
@@ -36,6 +36,7 @@ tnt_sbuf_object_grow_stack(struct tnt_sbuf_object *sbo)
 	struct tnt_sbo_stack *stack = tnt_mem_alloc(new_stack_alloc * sizeof(
 				struct tnt_sbo_stack));
 	if (!stack) return -1;
+	tnt_mem_free(sbo->stack);
 	sbo->stack_alloc = new_stack_alloc;
 	sbo->stack = stack;
 	return 0;
@@ -67,11 +68,11 @@ tnt_object(struct tnt_stream *s)
 
 	struct tnt_stream_buf *sb = TNT_SBUF_CAST(s);
 	sb->resize = tnt_sbuf_object_resize;
-	sb->free = tnt_sbuf_object_free;
 
 	struct tnt_sbuf_object *sbo = tnt_mem_alloc(sizeof(struct tnt_sbuf_object));
 	if (sbo == NULL)
 		goto error;
+	sb->free = tnt_sbuf_object_free;
 	sb->subdata = sbo;
 	sbo->stack_size = 0;
 	sbo->stack_alloc = 8;


### PR DESCRIPTION
Fixed memory leak in `tnt_sbuf_object_grow_stack` function.
Fixed SIGSEGV in case when memory allocation failure in `tnt_object` function.

Closes #139