### PR TITLE
readme: fix documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The current version is 1.0
 
 Tarantool-c depends on `msgpuck <https://github.com/tarantool/msgpuck>`_.
 
-For documentation, please, visit `github pages <http://tarantool.github.com/tarantool-c>`_.
+For documentation, please, visit `github pages <https://tarantool.github.io/tarantool-c>`_.
 
 It consinsts of:
 


### PR DESCRIPTION
GitHub Pages now served from github.io, not github.com. See [1] for
details.

Also changed http to https, because otherwise a malicious man in the
middle may offer its own tarantool-c documentation. Ha-ha. Actually,
because modern web browsers show a warning, when plain HTTP is used.

[1]: https://github.blog/2013-04-05-new-github-pages-domain-github-io/