### PR TITLE
fixing TNT_SBO_SPARSE/TNT_SBO_PACKED type objects serialization breaking if tnt_sbuf_object_grow_stack() gets called (effectively overwriting current stack array with zeroes)

### DIFF
--- a/tnt/tnt_object.c
+++ b/tnt/tnt_object.c
@@ -36,6 +36,7 @@ tnt_sbuf_object_grow_stack(struct tnt_sbuf_object *sbo)
 	struct tnt_sbo_stack *stack = tnt_mem_alloc(new_stack_alloc * sizeof(
 				struct tnt_sbo_stack));
 	if (!stack) return -1;
+	memcpy(stack, sbo->stack, sbo->stack_alloc * sizeof(*sbo->stack));
 	tnt_mem_free(sbo->stack);
 	sbo->stack_alloc = new_stack_alloc;
 	sbo->stack = stack;


### PR DESCRIPTION
reproducible with following:
----------------------------
[root@vostro tmp]# cat test.c
\#include <stdio.h>
\#include <stdlib.h>

\#include <tarantool/tarantool.h>
\#include <msgpuck.h>

void test(int levels)
{
        struct tnt_stream s;
        tnt_object(&s);
        tnt_object_type(&s, TNT_SBO_SPARSE);

        for (int i=0; i<levels; ++i)
        {
                tnt_object_add_array(&s, 0);
                tnt_object_add_uint(&s, i);
        }

        for (int i=0; i<levels; ++i)
                tnt_object_container_close(&s);

        mp_fprint(stdout, TNT_SBUF_DATA(&s));
	printf("\n");
}

int main(int argc, char **argv)
{
	for (int i=1; i<argc; ++i)
		test(atoi(argv[i]));
	return 0;
}
[root@vostro tmp]#

[root@vostro tmp]# gcc test.c -o test /usr/lib64/libmsgpuck.a /usr/lib64/libtarantool.a

[root@vostro tmp]# ./test 8
[0, [1, [2, [3, [4, [5, [6, [7]]]]]]]]
[root@vostro tmp]#

[root@vostro tmp]# ./test 9
[]
[root@vostro tmp]#
----------------------------