### PR TITLE
cd: add packages deploy on push with tag

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -37,7 +37,7 @@ jobs:
       DIST: ${{ matrix.platform.dist }}
 
     steps:
-      - name: Clone the module
+      - name: Clone the connector
         uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -49,5 +49,36 @@ jobs:
           repository: packpack/packpack
           path: packpack
 
+      - name: Fetch tags
+        # Found that Github checkout Actions pulls all the tags, but
+        # right it deannotates the testing tag, check:
+        #   https://github.com/actions/checkout/issues/290
+        # But we use 'git describe ..' calls w/o '--tags' flag and it
+        # prevents us from getting the needed tag for packages version
+        # setup. To avoid of it, let's fetch it manually, to be sure
+        # that all tags will exists always.
+        run: git fetch --tags -f
+
       - name: Create packages
         run: ./packpack/packpack
+
+      - name: Deploy packages
+        # We need this step to run only on push with tag.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RWS_URL_PART: https://rws.tarantool.org/release/enabled
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          PRODUCT_NAME: tarantool-c
+        run: |
+          CURL_CMD="curl -LfsS \
+            -X PUT ${RWS_URL_PART}/${OS}/${DIST} \
+            -u ${RWS_AUTH} \
+            -F product=${PRODUCT_NAME}"
+
+          for f in $(ls -I '*build*' -I '*.changes' ./build); do
+            CURL_CMD+=" -F $(basename ${f})=@./build/${f}"
+          done
+
+          echo ${CURL_CMD}
+
+          ${CURL_CMD}


### PR DESCRIPTION
Adds "Deploy pakages" step to .github/workflows/packaging.yml which
deploys packages to our S3-based repositories. This step is triggered
only on push with any tag. Based on [1].
Adds "Fetch tags" step before creating packages with packpack. Using
Github checkout Actions and 'git describe ..' calls w/o '--tags' flag
we are unable to get the needed tag for packages version setup.
'git fetch --tags -f' fixes it. For more information, see [2].

[1] [.github/actions/upload/action.yml from tarantool/rws](https://github.com/tarantool/rws/blob/15f2450c3826794e65f5e6e0e16694806685c451/.github/actions/upload/action.yml)
[2] [.github/actions/environment/action.yml from tarantool/tarantool](https://github.com/tarantool/tarantool/blob/3a98e0794e06bee9ecccbe2bc875e87f612d5560/.github/actions/environment/action.yml)

Needed for https://github.com/tarantool/tarantool-c/issues/145.