### PR TITLE
 test: update SQL test for tarantool.compat switch 

### DIFF
--- a/test/unix/tarantool_unix.c
+++ b/test/unix/tarantool_unix.c
@@ -358,7 +358,7 @@ test_execute(const char *uri) {
 	args = tnt_object(NULL);
 	isnt(args, NULL, "Check object creation");
 	isnt(tnt_object_format(args, "[]"), -1, "check object filling");
-	query = "select * from test_table";
+	query = "select * from test_table where id = 0";
 	isnt(tnt_execute(tnt, query, strlen(query), args), -1,
 	     "Create execute sql request: select");
 	isnt(tnt_flush(tnt), -1, "Send to server");


### PR DESCRIPTION
sql_seq_scan compat option[1] is turned to new behavior
by default in tarantool 3.0 release. An according sql test
in the connector now performs a specific scan instead of
a full one.   

[1]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/compat/sql_seq_scan_default/