### PR TITLE
ci: bump test-run

### DIFF
--- a/test/cli/tarantool-poll.test.py
+++ b/test/cli/tarantool-poll.test.py
@@ -8,7 +8,11 @@ suite_name = 'cli'
 test_name = 'tarantool-poll'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
+new_env = os.environ.copy()
+new_env["LISTEN"] = f"localhost:{server.get_iproto_port()}"
+
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT,
+                       stdout = subprocess.PIPE, universal_newlines=True, env=new_env)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/test/cli/tarantool-tcp.test.py
+++ b/test/cli/tarantool-tcp.test.py
@@ -8,7 +8,11 @@ suite_name = 'cli'
 test_name = 'tarantool-tcp'
 path = os.path.join(os.environ['BUILDDIR'], 'test', suite_name, test_name)
 
-obj = subprocess.Popen([path], stderr = subprocess.STDOUT, stdout = subprocess.PIPE, universal_newlines=True)
+new_env = os.environ.copy()
+new_env["LISTEN"] = f"localhost:{server.get_iproto_port()}"
+
+obj = subprocess.Popen([path], stderr = subprocess.STDOUT,
+                       stdout = subprocess.PIPE, universal_newlines=True, env=new_env)
 rv = obj.communicate()
 
 print("TAP version 13")

--- a/test/unix/suite.ini
+++ b/test/unix/suite.ini
@@ -2,5 +2,4 @@
 core = tarantool
 description = connect to tarantool using a unix socket
 script = box.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True


### PR DESCRIPTION
In the near future we plan to test Tarantool installed from a DEB/RPM package. Since 3.0.0-alpha1 release Tarantool packages don't have the tarantoolctl utility inside.

tarantoolctl was ebmed to the test-run project inself. The submodule has been updated to the latest version.

Part of tarantool/tarantool#9443