### PR TITLE
ci: bump actions in reusable_testing.yml

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone the tarantool-c connector
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/tarantool-c
           # Enable recursive submodules checkout as test-run git module is used
@@ -22,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -32,7 +32,7 @@ jobs:
         run: sudo dpkg -i tarantool*.deb
 
       - name: Setup python3 for tests
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4. Bump version of the `actions/setup-python` action to v5. It is needed for fixing the following GitHub warnings:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20

    The following actions uses node12 which is deprecated and will be
    forced to run on node16