### PR TITLE
ci: bump ubuntu version for reusable_testing

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -17,27 +17,27 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          - '1.10'
-          - '2.8'
-          - '2.9'
+          - '2.11'
+          - '3.2'
+          - '3.3'
 
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Enable recursive submodules checkout as test-run git module is used
           # for running tests.
           submodules: recursive
 
       - name: Setup tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
       - name: Setup python3 for tests
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - name: Install test requirements
         run: pip install -r test-run/requirements.txt

--- a/.github/workflows/osx_testing.yml
+++ b/.github/workflows/osx_testing.yml
@@ -18,23 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - macos-11
-          - macos-12
+          - macos-13
         tarantool:
-          # TODO: add 1.10 versions after resolving gh-159.
           - brew
-          - 2.4.1
-          - 2.4.2
-          - 2.4.3
-          - 2.5.1
-          - 2.5.2
-          - 2.5.3
-          - 2.6.1
-          - 2.6.2
-          - 2.6.3
-          - 2.7.1
-          - 2.7.2
-          - 2.8.1
+          - 2.11.6
+          - 3.2.1
+          - 3.3.1
           - master
 
     env:
@@ -53,23 +42,17 @@ jobs:
         run: brew install tarantool
         if: matrix.tarantool == 'brew'
 
+      - name: Setup python3 for tests
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Cache built tarantool ${{ env.T_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.T_DESTDIR }}
-          # v2 is due to https://github.com/actions/cache/issues/2
-          # and because the cache keys without -v2 may contain
-          # debug tarantool builds. It is desirable to have all
-          # build either debug or release (RelWithDebInfo), but
-          # we unable to build all releases in debug (see below).
-          #
-          # v3 is to re-verify all Mac OS builds after fix for the
-          # gh-6076 problem (see below).
-          #
-          # v4 added due to inability to clear the cache after v3 prefix.
-          # See https://github.com/github/docs/issues/14145
-          key: ${{ matrix.runs-on }}-${{ matrix.tarantool }}-v4
+          key: ${{ matrix.runs-on }}-${{ matrix.tarantool }}
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Install tarantool build dependencies
@@ -77,7 +60,7 @@ jobs:
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Clone tarantool ${{ env.T_VERSION }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: tarantool/tarantool
           ref: ${{ env.T_VERSION }}
@@ -88,17 +71,6 @@ jobs:
           # the version list.
           fetch-depth: 0
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
-
-      - name: Patching tarantool for successful build
-        run: |
-          cd "${T_SRCDIR}"
-          # These steps fix the problem with tarantool build described in
-          # https://github.com/tarantool/tarantool/issues/6576
-          #
-          # -f is added to fix tarantool build on Mac OS
-          # See https://github.com/tarantool/smtp/commit/c771f3f17bf74d2bc7c979e78e15c48225b97015
-          git show 11e87877df9001a4972019328592d79d55d1bb01 | patch -p1 -f
-        if: matrix.tarantool != 'brew' && matrix.tarantool != 'master' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Build tarantool ${{ env.T_VERSION }} from sources
         run: |
@@ -163,7 +135,7 @@ jobs:
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Clone the connector
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ env.SRCDIR }}
           # Needed because of tarantool-c dependence on submodules

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       artifact_name:
         description: The name of the tarantool build artifact
-        default: ubuntu-focal
+        default: ubuntu-noble
         required: false
         type: string
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the tarantool-c connector
         uses: actions/checkout@v4


### PR DESCRIPTION
This patch bumps the Ubuntu distro version up to 24.04 (noble) in the aforementioned workflow, since the Ubuntu 20.04 (focal) image support will be dropped soon in the GitHub actions.

See also: actions/runner-images#11101